### PR TITLE
Solution6

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -23,6 +23,10 @@ class CommentsController < ApplicationController
     end
   end
 
+  def weekly_top_commenters
+    @top_commenters = WeeklyTopCommenters.new.call
+  end
+
   private
 
   def comment_params

--- a/app/queries/weekly_top_commenters.rb
+++ b/app/queries/weekly_top_commenters.rb
@@ -1,0 +1,16 @@
+class WeeklyTopCommenters
+  def call
+    top_commenters
+  end
+
+  private
+
+  def top_commenters
+    User
+      .joins(:comments)
+      .group('user_id')
+      .where('comments.created_at >= ?', 1.week.ago)
+      .order(Arel.sql('count(comments.id) desc'))
+      .limit(10)
+  end
+end

--- a/app/views/comments/weekly_top_commenters.html.haml
+++ b/app/views/comments/weekly_top_commenters.html.haml
@@ -1,0 +1,11 @@
+%h2.text-center Top commenters
+%table{border:  1, align: "center"}
+  %body
+    %tr
+      %th Commenter name
+      %th Number of comments
+    - @top_commenters.each do |top_commenter|
+      %tr
+        %td= top_commenter.name
+        %td= top_commenter.comments.count
+        %br/

--- a/app/views/layouts/_navigation_links.html.haml
+++ b/app/views/layouts/_navigation_links.html.haml
@@ -1,4 +1,5 @@
 %li= link_to 'Movies', movies_path
 %li= link_to 'Genres', genres_path
+%li= link_to 'Top commenters', top_commenters_path
 - if user_signed_in?
   %li= link_to 'Export', export_movies_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
     end
   end
   resources :comments, only: [:create, :destroy]
+  get 'top_commenters', to: 'comments#weekly_top_commenters'
 end

--- a/db/migrate/20191025111633_create_comments.rb
+++ b/db/migrate/20191025111633_create_comments.rb
@@ -6,7 +6,7 @@ class CreateComments < ActiveRecord::Migration[5.2]
       t.references :movie, foreign_key: true
       t.references :user,  foreign_key: true
 
-      t.timestamp
+      t.timestamps
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,8 @@ ActiveRecord::Schema.define(version: 2019_10_25_111633) do
     t.text "body"
     t.integer "movie_id"
     t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["movie_id"], name: "index_comments_on_movie_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end


### PR DESCRIPTION
I have created query object in order to withdraw unnecessary logic from comments controller. Alongside I added a link in navbar to separate page with a table of current top commenters matching given conditions.

I had to rollback latest migration (CreateComment) as I wrote incorrectly timestamps without an 's' and where clausule would not work as there was no such column as created_at.